### PR TITLE
fix: don't load unassigned codewords when there are none

### DIFF
--- a/R/convenience.R
+++ b/R/convenience.R
@@ -201,10 +201,11 @@ LoadXenium <- function(data.dir, fov = 'fov', assay = 'Xenium') {
   )
 
   xenium.obj <- CreateSeuratObject(counts = data$matrix[["Gene Expression"]], assay = assay)
-  if("Blank Codeword" %in% names(data$matrix))
+  if("Blank Codeword" %in% names(data$matrix)) {
     xenium.obj[["BlankCodeword"]] <- CreateAssayObject(counts = data$matrix[["Blank Codeword"]])
-  else
+  } else if("Unassigned Codeword" %in% names(data$matrix)) {
     xenium.obj[["BlankCodeword"]] <- CreateAssayObject(counts = data$matrix[["Unassigned Codeword"]])
+  }
   xenium.obj[["ControlCodeword"]] <- CreateAssayObject(counts = data$matrix[["Negative Control Codeword"]])
   xenium.obj[["ControlProbe"]] <- CreateAssayObject(counts = data$matrix[["Negative Control Probe"]])
 


### PR DESCRIPTION
Thanks for addressing an issue with loading Xenium data with Seurat! There is one other small piece of the puzzle, and it is that when there are no unassigned codewords (i.e. because there are 480 RNA targets and 20 negative controls), this feature type will not exist and it will fail to load. This one liner will avoid that situation. Would be nice to merge this through with your fix in one fell swoop.